### PR TITLE
Track progress

### DIFF
--- a/api/profile/controllers/profile.js
+++ b/api/profile/controllers/profile.js
@@ -8,13 +8,10 @@ module.exports = {
       if (user.profile) {
         const entity = await strapi.services.profile.findOne({ id: user.profile });
         return sanitizeEntity(entity, { model: strapi.models.profile });
-
+      } else {
+        return {};
       }
-      else {
-        return {}
-      }
-    }
-    else {
+    } else {
       //return ctx.response.badRequest(`Course slug must be unique ${slug}`);
       return ctx.unauthorized(`You can't see me`);
     }
@@ -22,12 +19,36 @@ module.exports = {
   async update(ctx) {
     const user = ctx.state.user;
     const body = ctx.request.body;
-    const profile = { ...body, user:user.id };
+    let dataToSave;
+    if (body.completedlectures) {
+      const { course, lecture } = body.completedlectures;
+      dataToSave = { completedlectures: { [course]: [lecture] } };
+
+      if (user.profile) {
+        const userProfile = await strapi.services.profile.findOne({ id: user.profile });
+        if (userProfile.completedlectures) {
+          const completedCourseLectures = userProfile.completedlectures[course];
+          dataToSave = completedCourseLectures
+            ? {
+                completedlectures: {
+                  ...userProfile.completedlectures,
+                  [course]: [...completedCourseLectures, lecture],
+                },
+              }
+            : {
+                completedlectures: { ...userProfile.completedlectures, [course]: [lecture] },
+              };
+        }
+      }
+    } else {
+      dataToSave = body;
+    }
+
+    const profile = { ...dataToSave, user: user.id };
     let entity;
     if (user.profile) {
-      entity = await strapi.services.profile.update({id:user.profile}, profile);
-    }
-    else {
+      entity = await strapi.services.profile.update({ id: user.profile }, profile);
+    } else {
       entity = await strapi.services.profile.create(profile);
     }
     return sanitizeEntity(entity, { model: strapi.models.profile });


### PR DESCRIPTION
Modified logic of  PUT `/profiles/` route.
In PUT request endpoint receives an object with the following shape:

```{completedlectures : {course : courseId, lecture: lectureId}```

 Data type of completedlectures field is JSON, where keys are course ids and values are arrays with completed lecture ids. Here is an example:

```{
       "7": [ 47 ],
       "10": [ 76, 80, 74 ]
  }
```
UseCases:
1. User doesn't have a profile: creates a profile with adding data to one field - completedlectures.
2. User has an account, but completedlectures is null : creates JSON with course-lecture.
3.  User has an account, completedlectures is not null : adds new course/lecture if the course wasn't started, or update existing one by adding new completed lecture to the array of lecture in the course.

